### PR TITLE
Reuse socket

### DIFF
--- a/lib/tsd_client.rb
+++ b/lib/tsd_client.rb
@@ -12,7 +12,15 @@ module TSD
         host:    '0.0.0.0',
         port:    4242,
         timeout: 120, # seconds
+        retries: 3,
+        retry_interval: 1, # second
       }.merge options
+
+      connect
+    end
+
+    def connect
+      @socket = TCPSocket.open @options[:host], @options[:port]
     end
 
     def query options
@@ -34,15 +42,26 @@ module TSD
       end
     end
 
-    def put options
+    def put options, retries = @options[:retries]
       Timeout::timeout @options[:timeout] do
-        TCPSocket.open @options[:host], @options[:port] do |socket|
-          socket.puts Format.put options
-
-          response, _, _ = socket.recvmsg_nonblock rescue nil
+        begin
+          @socket.puts Format.put options
+          response, _, _ = @socket.recvmsg_nonblock rescue nil
           response.chomp if response
+        rescue Exception => e
+          if retries > 0
+            sleep @options[:retry_interval]
+            $stderr.puts "Error: #{e}, retrying \##{retries}"
+            retries -= 1
+            # try to reconnect
+            connect
+            retry
+          else
+            raise e
+          end
         end
       end
     end
+
   end
 end

--- a/tsd_client.gemspec
+++ b/tsd_client.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |gem|
   gem.name     = 'tsd_client'
-  gem.version  = '0.1.0'
+  gem.version  = '0.1.1'
   gem.authors  = ['Dallas Marlow']
   gem.email    = ['dallasmarlow@gmail.com']
   gem.summary  = 'OpenTSDB client'


### PR DESCRIPTION
Currently every time a metric is submitted by calling `tsd.puts`, a new tcp connection is created, this PR reuse the first socket created and add retries. On retry it'll try to reestablish the connection as well.
